### PR TITLE
Add missing module tests

### DIFF
--- a/backend-javascript-esm/src/modules/city/__tests__/unit/city.repository.test.js
+++ b/backend-javascript-esm/src/modules/city/__tests__/unit/city.repository.test.js
@@ -1,0 +1,48 @@
+import Repository from '../../repositories/city.repository.js';
+import { ITEMS_MOCK_DATA } from '../../../../data/mocks/city.mock-data.js';
+
+describe('CityRepository', () => {
+  let repository;
+
+  beforeEach(() => {
+    repository = new Repository(false);
+    repository.repository.items = JSON.parse(JSON.stringify(ITEMS_MOCK_DATA));
+  });
+
+  describe('getItemById', () => {
+    test('returns a city by ID', async () => {
+      const expected = ITEMS_MOCK_DATA.find(item => item.id === 1);
+      const item = await repository.getItemById(1);
+      expect(item).toEqual(expected);
+    });
+
+    test('returns null if city not found', async () => {
+      const item = await repository.getItemById(999);
+      expect(item).toBeNull();
+    });
+  });
+
+  describe('updateItem', () => {
+    test('updates an existing city', async () => {
+      const itemId = 1;
+      const updatedData = { name: 'Updated City' };
+      const expected = { ...ITEMS_MOCK_DATA.find(i => i.id === itemId), ...updatedData };
+      const updatedItem = await repository.updateItem(itemId, updatedData);
+      const item = await repository.getItemById(itemId);
+      expect(updatedItem).toMatchObject(expected);
+      expect(item.name).toBe('Updated City');
+    });
+
+    test('returns null if city not found', async () => {
+      const result = await repository.updateItem(999, { name: 'none' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteItem', () => {
+    test('returns null if city not found', async () => {
+      const result = await repository.deleteItem(999);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend-javascript-esm/src/modules/city/__tests__/unit/city.service.test.js
+++ b/backend-javascript-esm/src/modules/city/__tests__/unit/city.service.test.js
@@ -1,0 +1,72 @@
+import Service from '../../services/city.service.js';
+import { ITEM_CONSTANTS } from '../../constants/city.constant.js';
+
+describe('CityService', () => {
+  let service;
+  let repository;
+
+  beforeEach(() => {
+    repository = {
+      getItemById: jest.fn(),
+      createItem: jest.fn(),
+      updateItem: jest.fn(),
+      deleteItem: jest.fn(),
+      existsByName: jest.fn(),
+      getItems: jest.fn(),
+    };
+    service = new Service(repository);
+  });
+
+  test('createItem throws when name already exists', async () => {
+    repository.existsByName.mockResolvedValue(true);
+    await expect(service.createItem({ name: 'Paris' }))
+      .rejects.toThrow(ITEM_CONSTANTS.ALREADY_EXISTS);
+  });
+
+  test('createItem creates a valid item', async () => {
+    const data = { name: 'Berlin' };
+    const created = { id: 5, name: 'Berlin' };
+    repository.existsByName.mockResolvedValue(false);
+    repository.createItem.mockResolvedValue(created);
+
+    const result = await service.createItem(data);
+    expect(result).toEqual(created);
+  });
+
+  test('getItemById throws when not found', async () => {
+    repository.getItemById.mockResolvedValue(null);
+    await expect(service.getItemById(999))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+
+  test('getItemById returns a city', async () => {
+    const item = { id: 1, name: 'Cincinnati' };
+    repository.getItemById.mockResolvedValue(item);
+    await expect(service.getItemById(1)).resolves.toEqual(item);
+  });
+
+  test('updateItem updates a city', async () => {
+    const updated = { id: 1, name: 'Updated' };
+    repository.updateItem.mockResolvedValue(updated);
+    await expect(service.updateItem(1, { name: 'Updated' })).resolves.toEqual(updated);
+  });
+
+  test('updateItem throws when not found', async () => {
+    repository.updateItem.mockResolvedValue(null);
+    await expect(service.updateItem(999, { name: 'none' }))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+
+  test('deleteItem removes a city', async () => {
+    const deleted = { id: 2, name: 'London' };
+    repository.deleteItem.mockResolvedValue(deleted);
+    const result = await service.deleteItem(2);
+    expect(result).toEqual(deleted);
+  });
+
+  test('deleteItem throws when not found', async () => {
+    repository.deleteItem.mockResolvedValue(null);
+    await expect(service.deleteItem(999))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+});

--- a/backend-javascript-esm/src/modules/continent/__tests__/unit/continent.repository.test.js
+++ b/backend-javascript-esm/src/modules/continent/__tests__/unit/continent.repository.test.js
@@ -1,0 +1,48 @@
+import Repository from '../../repositories/continent.repository.js';
+import { ITEMS_MOCK_DATA } from '../../../../data/mocks/continent.mock-data.js';
+
+describe('ContinentRepository', () => {
+  let repository;
+
+  beforeEach(() => {
+    repository = new Repository(false);
+    repository.repository.items = JSON.parse(JSON.stringify(ITEMS_MOCK_DATA));
+  });
+
+  describe('getItemById', () => {
+    test('returns a continent by ID', async () => {
+      const expected = ITEMS_MOCK_DATA.find(item => item.id === 1000);
+      const item = await repository.getItemById(1000);
+      expect(item).toEqual(expected);
+    });
+
+    test('returns null if continent not found', async () => {
+      const item = await repository.getItemById(9999);
+      expect(item).toBeNull();
+    });
+  });
+
+  describe('updateItem', () => {
+    test('updates an existing continent', async () => {
+      const itemId = 1000;
+      const updatedData = { name: 'Updated Continent' };
+      const expected = { ...ITEMS_MOCK_DATA.find(i => i.id === itemId), ...updatedData };
+      const updatedItem = await repository.updateItem(itemId, updatedData);
+      const item = await repository.getItemById(itemId);
+      expect(updatedItem).toMatchObject(expected);
+      expect(item.name).toBe('Updated Continent');
+    });
+
+    test('returns null if continent not found', async () => {
+      const result = await repository.updateItem(9999, { name: 'none' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteItem', () => {
+    test('returns null if continent not found', async () => {
+      const result = await repository.deleteItem(9999);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend-javascript-esm/src/modules/continent/__tests__/unit/continent.service.test.js
+++ b/backend-javascript-esm/src/modules/continent/__tests__/unit/continent.service.test.js
@@ -1,0 +1,72 @@
+import Service from '../../services/continent.service.js';
+import { ITEM_CONSTANTS } from '../../constants/continent.constant.js';
+
+describe('ContinentService', () => {
+  let service;
+  let repository;
+
+  beforeEach(() => {
+    repository = {
+      getItemById: jest.fn(),
+      createItem: jest.fn(),
+      updateItem: jest.fn(),
+      deleteItem: jest.fn(),
+      existsByName: jest.fn(),
+      getItems: jest.fn(),
+    };
+    service = new Service(repository);
+  });
+
+  test('createItem throws when name already exists', async () => {
+    repository.existsByName.mockResolvedValue(true);
+    await expect(service.createItem({ name: 'Europe' }))
+      .rejects.toThrow(ITEM_CONSTANTS.ALREADY_EXISTS);
+  });
+
+  test('createItem creates a valid item', async () => {
+    const data = { name: 'America' };
+    const created = { id: 10, name: 'America' };
+    repository.existsByName.mockResolvedValue(false);
+    repository.createItem.mockResolvedValue(created);
+
+    const result = await service.createItem(data);
+    expect(result).toEqual(created);
+  });
+
+  test('getItemById throws when not found', async () => {
+    repository.getItemById.mockResolvedValue(null);
+    await expect(service.getItemById(999))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+
+  test('getItemById returns a continent', async () => {
+    const item = { id: 1000, name: 'Africa' };
+    repository.getItemById.mockResolvedValue(item);
+    await expect(service.getItemById(1000)).resolves.toEqual(item);
+  });
+
+  test('updateItem updates a continent', async () => {
+    const updated = { id: 1000, name: 'Updated' };
+    repository.updateItem.mockResolvedValue(updated);
+    await expect(service.updateItem(1000, { name: 'Updated' })).resolves.toEqual(updated);
+  });
+
+  test('updateItem throws when not found', async () => {
+    repository.updateItem.mockResolvedValue(null);
+    await expect(service.updateItem(999, { name: 'none' }))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+
+  test('deleteItem removes a continent', async () => {
+    const deleted = { id: 1004, name: 'Europe' };
+    repository.deleteItem.mockResolvedValue(deleted);
+    const result = await service.deleteItem(1004);
+    expect(result).toEqual(deleted);
+  });
+
+  test('deleteItem throws when not found', async () => {
+    repository.deleteItem.mockResolvedValue(null);
+    await expect(service.deleteItem(999))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+});

--- a/backend-javascript-esm/src/modules/country/__tests__/unit/country.repository.test.js
+++ b/backend-javascript-esm/src/modules/country/__tests__/unit/country.repository.test.js
@@ -1,0 +1,48 @@
+import Repository from '../../repositories/country.repository.js';
+import { ITEMS_MOCK_DATA } from '../../../../data/mocks/country.mock-data.js';
+
+describe('CountryRepository', () => {
+  let repository;
+
+  beforeEach(() => {
+    repository = new Repository(false);
+    repository.repository.items = JSON.parse(JSON.stringify(ITEMS_MOCK_DATA));
+  });
+
+  describe('getItemById', () => {
+    test('returns a country by ID', async () => {
+      const expected = ITEMS_MOCK_DATA.find(item => item.id === 1);
+      const item = await repository.getItemById(1);
+      expect(item).toEqual(expected);
+    });
+
+    test('returns null if country not found', async () => {
+      const item = await repository.getItemById(999);
+      expect(item).toBeNull();
+    });
+  });
+
+  describe('updateItem', () => {
+    test('updates an existing country', async () => {
+      const itemId = 1;
+      const updatedData = { name: 'Updated Country' };
+      const expected = { ...ITEMS_MOCK_DATA.find(i => i.id === itemId), ...updatedData };
+      const updatedItem = await repository.updateItem(itemId, updatedData);
+      const item = await repository.getItemById(itemId);
+      expect(updatedItem).toMatchObject(expected);
+      expect(item.name).toBe('Updated Country');
+    });
+
+    test('returns null if country not found', async () => {
+      const result = await repository.updateItem(999, { name: 'none' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('deleteItem', () => {
+    test('returns null if country not found', async () => {
+      const result = await repository.deleteItem(999);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend-javascript-esm/src/modules/country/__tests__/unit/country.service.test.js
+++ b/backend-javascript-esm/src/modules/country/__tests__/unit/country.service.test.js
@@ -1,0 +1,70 @@
+import Service from '../../services/country.service.js';
+import { ITEM_CONSTANTS } from '../../constants/country.constant.js';
+
+describe('CountryService', () => {
+  let service;
+  let repository;
+
+  beforeEach(() => {
+    repository = {
+      getItemById: jest.fn(),
+      createItem: jest.fn(),
+      updateItem: jest.fn(),
+      deleteItem: jest.fn(),
+      existsByName: jest.fn(),
+      getItems: jest.fn(),
+    };
+    service = new Service(repository);
+  });
+
+  test('createItem throws when name already exists', async () => {
+    repository.existsByName.mockResolvedValue(true);
+    await expect(service.createItem({ name: 'France' }))
+      .rejects.toThrow(ITEM_CONSTANTS.ALREADY_EXISTS);
+  });
+
+  test('createItem creates a valid item', async () => {
+    const data = { name: 'Germany' };
+    const created = { id: 3, name: 'Germany' };
+    repository.existsByName.mockResolvedValue(false);
+    repository.createItem.mockResolvedValue(created);
+
+    const result = await service.createItem(data);
+    expect(result).toEqual(created);
+  });
+
+  test('getItemById throws when not found', async () => {
+    repository.getItemById.mockResolvedValue(null);
+    await expect(service.getItemById(999)).rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+
+  test('getItemById returns a country', async () => {
+    const item = { id: 1, name: 'France' };
+    repository.getItemById.mockResolvedValue(item);
+    await expect(service.getItemById(1)).resolves.toEqual(item);
+  });
+
+  test('updateItem updates a country', async () => {
+    const updated = { id: 1, name: 'Updated' };
+    repository.updateItem.mockResolvedValue(updated);
+    await expect(service.updateItem(1, { name: 'Updated' })).resolves.toEqual(updated);
+  });
+
+  test('updateItem throws when not found', async () => {
+    repository.updateItem.mockResolvedValue(null);
+    await expect(service.updateItem(999, { name: 'none' }))
+      .rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+
+  test('deleteItem removes a country', async () => {
+    const deleted = { id: 2, name: 'Spain' };
+    repository.deleteItem.mockResolvedValue(deleted);
+    const result = await service.deleteItem(2);
+    expect(result).toEqual(deleted);
+  });
+
+  test('deleteItem throws when not found', async () => {
+    repository.deleteItem.mockResolvedValue(null);
+    await expect(service.deleteItem(999)).rejects.toThrow(ITEM_CONSTANTS.NOT_FOUND);
+  });
+});


### PR DESCRIPTION
## Summary
- add service & repository tests for city, country and continent modules

## Testing
- `npx jest src/modules/city/__tests__/unit/city.service.test.js` *(fails: Cannot find module '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_6853ed083e6883238237d78a39f57793